### PR TITLE
remove unnecessary PublicKey import in main.ts

### DIFF
--- a/01-hello-world/src/main.ts
+++ b/01-hello-world/src/main.ts
@@ -5,7 +5,6 @@ import {
   Field,
   Mina,
   PrivateKey,
-  PublicKey,
   AccountUpdate,
 } from 'snarkyjs';
 


### PR DESCRIPTION
The [hello world tutorial docs page](https://docs.minaprotocol.com/zkapps/tutorials/hello-world) links to this file and the code snippet in it does not have the `PublicKey` class imported.