### PR TITLE
Update Hello World Main.ts to use proofsEnabled: false

### DIFF
--- a/01-hello-world/src/main.ts
+++ b/01-hello-world/src/main.ts
@@ -34,6 +34,7 @@ import {
     AccountUpdate.fundNewAccount(deployerAccount);
     zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });
   });
+
   await deploy_txn.prove();
   deploy_txn.sign([zkAppPrivateKey]);
   await deploy_txn.send();
@@ -46,8 +47,9 @@ import {
 
   const txn1 = await Mina.transaction(deployerAccount, () => {
     zkAppInstance.update(Field(9));
-    zkAppInstance.sign(zkAppPrivateKey);
   });
+
+  await txn1.prove();
   await txn1.send();
 
   const num1 = zkAppInstance.num.get();

--- a/01-hello-world/src/main.ts
+++ b/01-hello-world/src/main.ts
@@ -33,8 +33,9 @@ import {
   const deploy_txn = await Mina.transaction(deployerAccount, () => {
     AccountUpdate.fundNewAccount(deployerAccount);
     zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });
-    zkAppInstance.sign(zkAppPrivateKey);
   });
+  await deploy_txn.prove();
+  deploy_txn.sign([zkAppPrivateKey]);
   await deploy_txn.send();
 
   // get the initial state of Square after deployment

--- a/01-hello-world/src/main.ts
+++ b/01-hello-world/src/main.ts
@@ -13,13 +13,12 @@ import {
 
   console.log('SnarkyJS loaded');
 
-  const Local = Mina.LocalBlockchain();
+  const proofsEnabled = false;
+  const Local = Mina.LocalBlockchain({ proofsEnabled });
   Mina.setActiveInstance(Local);
   const deployerAccount = Local.testAccounts[0].privateKey;
 
-  const useProof = false;
-
-  if (useProof) {
+  if (proofsEnabled) {
     Square.compile();
   }
 

--- a/01-hello-world/src/main.ts
+++ b/01-hello-world/src/main.ts
@@ -75,13 +75,9 @@ import {
 
   const txn3 = await Mina.transaction(deployerAccount, () => {
     zkAppInstance.update(Field(81));
-    if (!useProof) {
-      zkAppInstance.sign(zkAppPrivateKey);
-    }
   });
-  if (useProof) {
-    await txn3.prove();
-  }
+
+  await txn3.prove();
   await txn3.send();
 
   const num3 = zkAppInstance.num.get();

--- a/01-hello-world/src/main.ts
+++ b/01-hello-world/src/main.ts
@@ -60,12 +60,14 @@ import {
   try {
     const txn2 = await Mina.transaction(deployerAccount, () => {
       zkAppInstance.update(Field(75));
-      zkAppInstance.sign(zkAppPrivateKey);
     });
+
+    await txn2.prove();
     await txn2.send();
   } catch (ex: any) {
     console.log(ex.message);
   }
+
   const num2 = zkAppInstance.num.get();
   console.log('state after txn2:', num2.toString());
 


### PR DESCRIPTION
This PR updates the main.js script that runs a local blockchain to set proofsEnabled false. All instances of using contract.sign() inside of a transaction were moved because it is deprecated with SnarkyJS 0.7.1. Transactions that need to be signed with a zkAppKey can now be signed ie `deploy_txn.sign([zkAppPrivateKey])`. 