### PR TITLE
Some fixes in 09-recursion to make the examples run

### DIFF
--- a/09-recursion/src/rollup.ts
+++ b/09-recursion/src/rollup.ts
@@ -77,20 +77,32 @@ async function main() {
 
   // These could all be done in parallel in a real rollup
   // If T is the time to make a proof this could take time T
-  const rollupProofs = rollupStepInfo.map(async ({ initialRoot, latestRoot, key, currentValue, increment, witness }) => {
+  // const rollupProofs = rollupStepInfo.map(async ({ initialRoot, latestRoot, key, currentValue, increment, witness }) => {
+  //   const rollup = RollupState.createOneStep(initialRoot, latestRoot, key, currentValue, increment, witness);
+  //   const proof = await Rollup.oneStep(rollup, initialRoot, latestRoot, key, currentValue, increment, witness);
+  //   return proof;
+  // });
+  const rollupProofs: Proof<RollupState>[] = [];
+  for (var { initialRoot, latestRoot, key, currentValue, increment, witness } of rollupStepInfo) {
     const rollup = RollupState.createOneStep(initialRoot, latestRoot, key, currentValue, increment, witness);
     const proof = await Rollup.oneStep(rollup, initialRoot, latestRoot, key, currentValue, increment, witness);
-    return proof;
-  });
+    rollupProofs.push(proof);
+  }
 
   console.log('merging proofs');
 
   // These could also all be done in parallel in a real rollup
   // If T is the time to make a proof this could take time log(n)*T
-  const proof = await rollupProofs.reduce(async (a, b) => {
-    const rollup = RollupState.createMerged((await a).publicInput, (await b).publicInput);
-    return await Rollup.merge(rollup, (await a), (await b));
-  });
+  // const proof = await rollupProofs.reduce(async (a, b) => {
+  //   const rollup = RollupState.createMerged((await a).publicInput, (await b).publicInput);
+  //   return await Rollup.merge(rollup, (await a), (await b));
+  // });
+  var proof: Proof<RollupState> = rollupProofs[0];
+  for (let i=1; i<rollupProofs.length; i++) {
+    const rollup = RollupState.createMerged(proof.publicInput, rollupProofs[i].publicInput);
+    let mergedProof = await Rollup.merge(rollup, proof, rollupProofs[i]);
+    proof = mergedProof;
+  }
 
   console.log('verifying rollup');
   console.log(proof.publicInput.latestRoot.toString());

--- a/09-recursion/src/rollup.ts
+++ b/09-recursion/src/rollup.ts
@@ -64,9 +64,10 @@ async function main() {
     const witness = map.getWitness(key);
     const initialRoot = map.getRoot();
 
-    const currentValue = map.get(key).add(increment)
+    const currentValue = map.get(key);
+    const updatedValue = map.get(key).add(increment);
 
-    map.set(key, currentValue);
+    map.set(key, updatedValue);
     const latestRoot = map.getRoot();
 
     rollupStepInfo.push({ initialRoot, latestRoot, key, currentValue, increment, witness });
@@ -183,7 +184,7 @@ const Rollup = Experimental.ZkProgram({
         rollup1proof.verify();
         rollup2proof.verify();
 
-        rollup1proof.publicInput.initialRoot.assertEquals(rollup1proof.publicInput.latestRoot);
+        rollup2proof.publicInput.initialRoot.assertEquals(rollup1proof.publicInput.latestRoot);
         rollup1proof.publicInput.initialRoot.assertEquals(newState.initialRoot);
         rollup2proof.publicInput.latestRoot.assertEquals(newState.latestRoot);
       }

--- a/09-recursion/src/vote.ts
+++ b/09-recursion/src/vote.ts
@@ -68,7 +68,7 @@ async function main() {
   console.log('verifying proof 2');
   console.log(proof2.publicInput.voteFor.toString(), proof2.publicInput.voteAgainst.toString());
 
-  const ok = await verify(proof2.toJSON(), verificationKey);
+  const ok = await Vote.verify(proof2);
   console.log('ok', ok);
 
   console.log('Shutting down');


### PR DESCRIPTION
1. Fixed a trivial bug in rollup.ts
2. in vote.ts: When using `await verify(proof2.toJSON(), verificationKey)`, the program will exit with error `bad verify: dlog_check`. Changed to `await Vote.verify(proof2)`. I got this solution from discord.
3. in rollup.ts: When using map and reduce, the program will get `Error: It seems you're running multiple provers concurrently within the same JavaScript thread, which, at the moment, is not supported and would lead to bugs.`. Changed to normal for loop to synchronize the proof iteration. IDK if I missed some information, does the internal version of snarkyjs already support running provers in parallelism? :)